### PR TITLE
[DATA-3864] Synapse PR Feedback

### DIFF
--- a/.github/workflows/test_destination_synapse.yml
+++ b/.github/workflows/test_destination_synapse.yml
@@ -8,7 +8,6 @@ on:
       - master
       - devel
       - synapse
-      - feedback
   
 env:
   DESTINATION__SYNAPSE__CREDENTIALS: ${{ secrets.SYNAPSE_CREDENTIALS }}

--- a/.github/workflows/test_destination_synapse.yml
+++ b/.github/workflows/test_destination_synapse.yml
@@ -8,6 +8,7 @@ on:
       - master
       - devel
       - synapse
+      - feedback
   
 env:
   DESTINATION__SYNAPSE__CREDENTIALS: ${{ secrets.SYNAPSE_CREDENTIALS }}

--- a/dlt/destinations/insert_job_client.py
+++ b/dlt/destinations/insert_job_client.py
@@ -10,6 +10,7 @@ from dlt.common.utils import chunks
 from dlt.destinations.sql_client import SqlClientBase
 from dlt.destinations.job_impl import EmptyLoadJob
 from dlt.destinations.job_client_impl import SqlJobClientWithStaging
+from tests.utils import ACTIVE_DESTINATIONS
 
 
 class InsertValuesLoadJob(LoadJob, FollowupJob):
@@ -57,48 +58,49 @@ class InsertValuesLoadJob(LoadJob, FollowupJob):
                     # print(f'replace the "," with " {until_nl} {len(insert_sql)}')
                     until_nl = until_nl[:-1] + ";"
 
-                if max_rows is not None and max_rows<1000:
-                    # mssql has a limit of 1000 rows per INSERT, so we need to split into separate statements
-                    values_rows = content.splitlines(keepends=True)
-                    len_rows = len(values_rows)
-                    processed = 0
-                    # Chunk by max_rows - 1 for simplicity because one more row may be added
-                    for chunk in chunks(values_rows, max_rows - 1):
-                        processed += len(chunk)
-                        insert_sql.extend([header.format(qualified_table_name), values_mark])
-                        if processed == len_rows:
-                            # On the last chunk we need to add the extra row read
-                            insert_sql.append("".join(chunk) + until_nl)
-                        else:
-                            # Replace the , with ;
-                            insert_sql.append("".join(chunk).strip()[:-1] + ";\n")
-                elif max_rows >= 1000:
-                    # This part breaks the multiple values in an insert statement into individual insert statements 
-                    # combined with SELECT and UNION ALL
+                if max_rows is not None:
+                    if "synapse" in ACTIVE_DESTINATIONS:
+                        # This part breaks the multiple values in an insert statement into individual insert statements 
+                        # combined with SELECT and UNION ALL
 
-                    values_rows = content.splitlines(keepends=True)
-                    sql_rows = []
+                        values_rows = content.splitlines(keepends=True)
+                        sql_rows = []
 
-                    for row in values_rows:
-                        # Remove potential leading and trailing characters such as brackets, commas, and newlines
-                        row = row.strip(",\n() ;")
-                        
-                        # Separate out the individual values within the row
-                        columns = row.split(",")
-                        
-                        # Ensure there are no stray parentheses in columns
-                        columns = [col.strip("()") for col in columns]
-                        
-                        # Create the SELECT for this particular row, keeping the values as they are
-                        sql_rows.append(f"SELECT {', '.join(columns)}")
+                        for row in values_rows:
+                            # Remove potential leading and trailing characters such as brackets, commas, and newlines
+                            row = row.strip(",\n() ;")
+                            
+                            # Separate out the individual values within the row
+                            columns = row.split(",")
+                            
+                            # Ensure there are no stray parentheses in columns
+                            columns = [col.strip("()") for col in columns]
+                            
+                            # Create the SELECT for this particular row, keeping the values as they are
+                            sql_rows.append(f"SELECT {', '.join(columns)}")
 
-                    individual_insert = " UNION ALL ".join(sql_rows)
-                    
-                    # If individual_insert ends with a semicolon, remove it
-                    if individual_insert.endswith(";"):
-                        individual_insert = individual_insert[:-1]
-                    
-                    insert_sql.extend([header.format(qualified_table_name), individual_insert + ";"])
+                        individual_insert = " UNION ALL ".join(sql_rows)
+                        
+                        # If individual_insert ends with a semicolon, remove it
+                        if individual_insert.endswith(";"):
+                            individual_insert = individual_insert[:-1]
+                        
+                        insert_sql.extend([header.format(qualified_table_name), individual_insert + ";"])
+                    else:
+                        # mssql has a limit of 1000 rows per INSERT, so we need to split into separate statements
+                        values_rows = content.splitlines(keepends=True)
+                        len_rows = len(values_rows)
+                        processed = 0
+                        # Chunk by max_rows - 1 for simplicity because one more row may be added
+                        for chunk in chunks(values_rows, max_rows - 1):
+                            processed += len(chunk)
+                            insert_sql.extend([header.format(qualified_table_name), values_mark])
+                            if processed == len_rows:
+                                # On the last chunk we need to add the extra row read
+                                insert_sql.append("".join(chunk) + until_nl)
+                            else:
+                                # Replace the , with ;
+                                insert_sql.append("".join(chunk).strip()[:-1] + ";\n")
                 else:
                     # otherwise write all content in a single INSERT INTO
                     insert_sql.extend([header.format(qualified_table_name), values_mark, content])

--- a/dlt/destinations/insert_job_client.py
+++ b/dlt/destinations/insert_job_client.py
@@ -62,6 +62,7 @@ class InsertValuesLoadJob(LoadJob, FollowupJob):
                     if "synapse" in ACTIVE_DESTINATIONS:
                         # This part breaks the multiple values in an insert statement into individual insert statements 
                         # combined with SELECT and UNION ALL
+                        #https://stackoverflow.com/questions/36141006/how-to-insert-multiple-rows-into-sql-server-parallel-data-warehouse-table
 
                         values_rows = content.splitlines(keepends=True)
                         sql_rows = []

--- a/dlt/destinations/synapse/configuration.py
+++ b/dlt/destinations/synapse/configuration.py
@@ -65,7 +65,8 @@ class SynapseCredentials(ConnectionStringCredentials):
             "DATABASE": self.database,
             "UID": self.username,
             "PWD": self.password,
-            "LongAsMax": "yes"
+            "LongAsMax": "yes",
+            "MARS_Connection": "yes"
         }
         if self.query:
             params.update(self.query)

--- a/dlt/destinations/synapse/sql_client.py
+++ b/dlt/destinations/synapse/sql_client.py
@@ -91,6 +91,8 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
         table_names = [row[0] for row in rows]
         self.drop_tables(*table_names)
 
+        self._conn.commit()
+
         self.execute_sql("DROP SCHEMA %s;" % self.fully_qualified_dataset_name())
 
     def drop_tables(self, *tables: str) -> None:

--- a/dlt/destinations/synapse/sql_client.py
+++ b/dlt/destinations/synapse/sql_client.py
@@ -55,7 +55,7 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
     @contextmanager
     def begin_transaction(self) -> Iterator[DBTransaction]:
         try:
-            self._conn.autocommit = True
+            self._conn.autocommit = False
             yield self
             self.commit_transaction()
         except Exception:

--- a/dlt/destinations/synapse/sql_client.py
+++ b/dlt/destinations/synapse/sql_client.py
@@ -55,9 +55,9 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
     @contextmanager
     def begin_transaction(self) -> Iterator[DBTransaction]:
         try:
-            self._conn.autocommit = False
+            self._conn.autocommit = True
             yield self
-            self.commit_transaction()
+            #self.commit_transaction()
         except Exception:
             self.rollback_transaction()
             raise

--- a/dlt/destinations/synapse/sql_client.py
+++ b/dlt/destinations/synapse/sql_client.py
@@ -40,7 +40,6 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
             self.credentials.to_odbc_dsn(),
             timeout=self.credentials.connect_timeout,
         )
-        # https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function
         self._conn.add_output_converter(-155, handle_datetimeoffset)
         self._conn.autocommit = True
         print("Conn string: ", self.credentials.to_odbc_dsn())
@@ -77,35 +76,78 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
         return self._conn
 
     def drop_dataset(self) -> None:
-        # MS Sql doesn't support DROP ... CASCADE, drop tables in the schema first
-        # Drop all views
-        rows = self.execute_sql(
-            "SELECT table_name FROM information_schema.views WHERE table_schema = %s;", self.dataset_name
-        )
-        view_names = [row[0] for row in rows]
-        self._drop_views(*view_names)
-        # Drop all tables
-        rows = self.execute_sql(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s;", self.dataset_name
-        )
-        table_names = [row[0] for row in rows]
-        self.drop_tables(*table_names)
+        # Save the current autocommit state
+        # If a transaction is active, commit it
+        if not self._conn.autocommit:
+            self._conn.commit()
 
-        self._conn.commit()
+        # Save the current autocommit state
+        prev_autocommit = self._conn.autocommit
+        # Set autocommit to True for DDL operations
+        self._conn.autocommit = True
+        try:
+            rows = self.execute_sql(
+                "SELECT table_name FROM information_schema.views WHERE table_schema = %s;", self.dataset_name
+            )
+            view_names = [row[0] for row in rows]
+            self._drop_views(*view_names)
+            rows = self.execute_sql(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = %s;", self.dataset_name
+            )
+            table_names = [row[0] for row in rows]
+            self.drop_tables(*table_names)
 
-        self.execute_sql("DROP SCHEMA %s;" % self.fully_qualified_dataset_name())
+            self.execute_sql("DROP SCHEMA %s;" % self.fully_qualified_dataset_name())
+        finally:
+            # Reset autocommit to its previous state
+            self._conn.autocommit = prev_autocommit
+
+    def table_exists(self, table_name: str) -> bool:
+        query = """
+        SELECT COUNT(*) 
+        FROM INFORMATION_SCHEMA.TABLES 
+        WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+        """
+        result = self.execute_sql(query, self.dataset_name, table_name)
+        return result[0][0] > 0        
 
     def drop_tables(self, *tables: str) -> None:
         if not tables:
             return
-        statements = [f"DROP TABLE {self.make_qualified_table_name(table)};" for table in tables]
-        self.execute_fragments(statements)    
-    
+        # If a transaction is active, commit it
+        if not self._conn.autocommit:
+            self._conn.commit()
+
+        # Save the current autocommit state
+        prev_autocommit = self._conn.autocommit
+        # Set autocommit to True for DDL operations
+        self._conn.autocommit = True
+        try:
+            for table in tables:
+                if self.table_exists(table):
+                    self.execute_sql(f"DROP TABLE {self.make_qualified_table_name(table)};")
+        finally:
+            # Reset autocommit to its previous state
+            self._conn.autocommit = prev_autocommit
+
     def _drop_views(self, *tables: str) -> None:
-        if not tables:
-            return
-        statements = [f"DROP VIEW {self.make_qualified_table_name(table)};" for table in tables]
-        self.execute_fragments(statements)
+        # Save the current autocommit state
+        # If a transaction is active, commit it
+        if not self._conn.autocommit:
+            self._conn.commit()
+
+        # Save the current autocommit state
+        prev_autocommit = self._conn.autocommit
+        # Set autocommit to True for DDL operations
+        self._conn.autocommit = True
+        try:
+            if not tables:
+                return
+            statements = [f"DROP VIEW {self.make_qualified_table_name(table)};" for table in tables]
+            self.execute_fragments(statements)
+        finally:
+            # Reset autocommit to its previous state
+            self._conn.autocommit = prev_autocommit
 
     def execute_sql(self, sql: AnyStr, *args: Any, **kwargs: Any) -> Optional[Sequence[Sequence[Any]]]:
         with self.execute_query(sql, *args, **kwargs) as curr:
@@ -120,17 +162,28 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
     def execute_query(self, query: AnyStr, *args: Any, **kwargs: Any) -> Iterator[DBApiCursor]:
         assert isinstance(query, str)
         curr: DBApiCursor = None
+        
+        # Check if the query is a DDL operation
+        ddl_operations = ["DROP", "CREATE", "ALTER"]
+        is_ddl = any(op in query.upper() for op in ddl_operations)
+        
+        # If it's a DDL operation, set autocommit to True temporarily
+        prev_autocommit = self._conn.autocommit
+        if is_ddl:
+            if not prev_autocommit:
+                # If inside a transaction, commit it before executing DDL
+                self._conn.commit()
+            self._conn.autocommit = True
+        
         if kwargs:
             raise NotImplementedError("pyodbc does not support named parameters in queries")
         if args:
-            # TODO: this is bad. See duckdb & athena also
             query = query.replace("%s", "?")
         curr = self._conn.cursor()
+        
         try:
             print("Executing query:")
             print(query)
-            # unpack because empty tuple gets interpreted as a single argument
-            # https://github.com/mkleehammer/pyodbc/wiki/Features-beyond-the-DB-API#passing-parameters
             curr.execute(query, *args)
             yield DBApiCursorImpl(curr)  # type: ignore[abstract]
         except pyodbc.Error as outer:
@@ -139,6 +192,9 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
             print("Query error:")
             print(outer)
             raise outer
+        finally:
+            # Reset autocommit to its previous state after the operation
+            self._conn.autocommit = prev_autocommit
 
     def fully_qualified_dataset_name(self, escape: bool = True) -> str:
         return self.capabilities.escape_identifier(self.dataset_name) if escape else self.dataset_name

--- a/dlt/destinations/synapse/sql_client.py
+++ b/dlt/destinations/synapse/sql_client.py
@@ -55,9 +55,9 @@ class PyOdbcSynapseClient(SqlClientBase[pyodbc.Connection], DBTransaction):
     @contextmanager
     def begin_transaction(self) -> Iterator[DBTransaction]:
         try:
-            self._conn.autocommit = True
+            self._conn.autocommit = False
             yield self
-            #self.commit_transaction()
+            self.commit_transaction()
         except Exception:
             self.rollback_transaction()
             raise

--- a/dlt/destinations/synapse/synapse.py
+++ b/dlt/destinations/synapse/synapse.py
@@ -61,8 +61,6 @@ class SynapseStagingCopyJob(SqlStagingCopyJob):
             sql.append(f"DROP TABLE {table_name};")
             # moving staging table to destination schema
             sql.append(f"ALTER SCHEMA {sql_client.fully_qualified_dataset_name()} TRANSFER {staging_table_name};")
-            # recreate staging table
-            sql.append(f"SELECT * INTO {staging_table_name} FROM {table_name} WHERE 1 = 0;")
         return sql
 
 
@@ -80,11 +78,10 @@ class SynapseMergeJob(SqlMergeJob):
     def _to_temp_table(cls, select_sql: str, temp_table_name: str) -> str:
         return f"SELECT * INTO {temp_table_name} FROM ({select_sql}) as t;"
 
-    """@classmethod
+    @classmethod
     def _new_temp_table_name(cls, name_prefix: str) -> str:
         name = SqlMergeJob._new_temp_table_name(name_prefix)
         return '#' + name
-    """    
 
 class SynapseClient(InsertValuesJobClient):
     #TODO: Add a function to insert multiple values for several columns in insert sql to individual insert sql.

--- a/dlt/destinations/synapse/synapse.py
+++ b/dlt/destinations/synapse/synapse.py
@@ -80,10 +80,11 @@ class SynapseMergeJob(SqlMergeJob):
     def _to_temp_table(cls, select_sql: str, temp_table_name: str) -> str:
         return f"SELECT * INTO {temp_table_name} FROM ({select_sql}) as t;"
 
-    @classmethod
+    """@classmethod
     def _new_temp_table_name(cls, name_prefix: str) -> str:
         name = SqlMergeJob._new_temp_table_name(name_prefix)
         return '#' + name
+    """    
 
 class SynapseClient(InsertValuesJobClient):
     #TODO: Add a function to insert multiple values for several columns in insert sql to individual insert sql.


### PR DESCRIPTION
Updates the Synapse destination from feedback from [WIP PR](https://github.com/dlt-hub/dlt/pull/649):

1. Removes `SELECT * INTO` query in generate_sql
2. Removes `max_rows >= 1000` conditional for UNION ALL approach in `_insert` function, and adds comment with stackoverflow link describing UNION ALL code
3. Adds `"MARS_Connection": "yes"` to connection string to handle running multiple queries in a single connection 
4. Updates `drop_dataset` function to resolve errors with transactions erroring from `autocommit` 